### PR TITLE
Misc improvements (#66)

### DIFF
--- a/resource-discovery/src/main/java/eu/nebulous/resource/discovery/broker_communication/BrokerPublisher.java
+++ b/resource-discovery/src/main/java/eu/nebulous/resource/discovery/broker_communication/BrokerPublisher.java
@@ -16,6 +16,7 @@ import java.util.*;
 public class BrokerPublisher {
     public static String EMPTY="";
     //private HashMap<String, HashSet<String>> broker_and_topics_to_publish_to = new HashMap<>();
+    private static HashMap<String, BrokerPublisher> hostnames_topics_broker_publishers = new HashMap<>();
     private Publisher private_publisher_instance;
     private ArrayList<Publisher> publishers = new ArrayList<>();
 
@@ -25,8 +26,16 @@ public class BrokerPublisher {
     private String broker_ip;
     private int broker_port;
 
-    
+    public static BrokerPublisher getExistingOrNewBrokerPublisher(String topic, String broker_ip, int broker_port, String brokerUsername, String brokerPassword, String amqLibraryConfigurationLocation) {
+        if (hostnames_topics_broker_publishers.containsKey(broker_ip + "," + topic)){
+            return(hostnames_topics_broker_publishers.get(broker_ip + "," + topic));
+        }else{
+            return(new BrokerPublisher(topic, broker_ip, broker_port, brokerUsername, brokerPassword, amqLibraryConfigurationLocation));
+        }
+    }
     public BrokerPublisher(String topic, String broker_ip, int broker_port, String brokerUsername, String brokerPassword, String amqLibraryConfigurationLocation) {
+        
+
         boolean able_to_initialize_BrokerPublisher = topic!=null && broker_ip!=null && brokerUsername!=null && brokerPassword!=null && !topic.equals(EMPTY) && !broker_ip.equals(EMPTY) && !brokerUsername.equals(EMPTY) && !brokerPassword.equals(EMPTY);
 
         if (!able_to_initialize_BrokerPublisher){
@@ -102,8 +111,9 @@ public class BrokerPublisher {
                     )
             );
             active_connector.start();
-
+        
         //}
+        hostnames_topics_broker_publishers.put(broker_ip+","+topic,this);
     }
 
     //TODO The methods below assume that the only content to be sent is json-like

--- a/resource-discovery/src/main/java/eu/nebulous/resource/discovery/broker_communication/CustomConnectorHandler.java
+++ b/resource-discovery/src/main/java/eu/nebulous/resource/discovery/broker_communication/CustomConnectorHandler.java
@@ -17,6 +17,7 @@ public class CustomConnectorHandler extends ConnectorHandler {
             this.ready.set(true);
             this.ready.notifyAll();
         }
+        
     }
     public void remove_consumer_with_key(String key){
         context.unregisterConsumer(key);

--- a/resource-discovery/src/main/java/eu/nebulous/resource/discovery/monitor/DeviceProcessor.java
+++ b/resource-discovery/src/main/java/eu/nebulous/resource/discovery/monitor/DeviceProcessor.java
@@ -164,7 +164,7 @@ public class DeviceProcessor  implements InitializingBean {
                     }
                     sending_attempt++;
                 }
-                device_lost_publisher.publish(lost_device_message.toJSONString(), Collections.singleton(""),true);
+                device_lost_publisher.publish(lost_device_message.toJSONString(), Collections.singleton(""),false);
                 log.warn("processFailedDevices: Marked as FAILED device with Id: {}", device.getId());
                 //device_lost_publisher.stop();
             }

--- a/resource-discovery/src/main/java/eu/nebulous/resource/discovery/monitor/DeviceProcessor.java
+++ b/resource-discovery/src/main/java/eu/nebulous/resource/discovery/monitor/DeviceProcessor.java
@@ -28,6 +28,8 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import static eu.nebulous.resource.discovery.broker_communication.BrokerPublisher.getExistingOrNewBrokerPublisher;
+
 @Slf4j
 @Service
 @EnableAsync
@@ -154,7 +156,7 @@ public class DeviceProcessor  implements InitializingBean {
                         log.warn("Will now make attempt No "+sending_attempt+" to (re)create the BrokerPublisher connector for the lost device topic");
                         log.info("The topic name is "+processorProperties.getLost_device_topic()+", the broker ip is "+ processorProperties.getNebulous_broker_ip_address()+", the broker port is "+ processorProperties.getNebulous_broker_port()+", the username is "+ processorProperties.getNebulous_broker_username()+", and the password is "+ processorProperties.getNebulous_broker_password());
                         
-                        device_lost_publisher = new BrokerPublisher(processorProperties.getLost_device_topic(), processorProperties.getNebulous_broker_ip_address(), processorProperties.getNebulous_broker_port(), processorProperties.getNebulous_broker_username(), processorProperties.getNebulous_broker_password(), "");
+                        device_lost_publisher = getExistingOrNewBrokerPublisher(processorProperties.getLost_device_topic(), processorProperties.getNebulous_broker_ip_address(), processorProperties.getNebulous_broker_port(), processorProperties.getNebulous_broker_username(), processorProperties.getNebulous_broker_password(), "");
                     
                         Thread.sleep(3000);
                     }catch (InterruptedException i){

--- a/resource-discovery/src/main/java/eu/nebulous/resource/discovery/registration/controller/RegistrationRequestController.java
+++ b/resource-discovery/src/main/java/eu/nebulous/resource/discovery/registration/controller/RegistrationRequestController.java
@@ -138,7 +138,7 @@ public class RegistrationRequestController implements InitializingBean {
 		String empty_response = null; //"{\"nonce\": \"" + nonce + "\", \"username\": \"" + "" + "\"}";
 		
 		log.debug("Sending nonce message to middleware");
-		nonce_publisher.publish(json_request.toJSONString(),List.of(""),true);
+		nonce_publisher.publish(json_request.toJSONString(),List.of(""),false);
 
 		
 		int cumulative_sleep = 0;

--- a/resource-discovery/src/main/java/eu/nebulous/resource/discovery/registration/controller/RegistrationRequestController.java
+++ b/resource-discovery/src/main/java/eu/nebulous/resource/discovery/registration/controller/RegistrationRequestController.java
@@ -28,6 +28,8 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.function.BiFunction;
 
+import static eu.nebulous.resource.discovery.broker_communication.BrokerPublisher.getExistingOrNewBrokerPublisher;
+
 @Slf4j
 @RestController
 @RequiredArgsConstructor
@@ -54,7 +56,7 @@ public class RegistrationRequestController implements InitializingBean {
 
 		log.debug("Initializing connector");
 		if (!has_initialized_nonce_connector){
-			nonce_publisher = new BrokerPublisher(GET_USER_TOPIC,processorPropertiesStatic.getNebulous_broker_ip_address(), processorPropertiesStatic.getNebulous_broker_port(), processorPropertiesStatic.getNebulous_broker_username(), processorPropertiesStatic.getNebulous_broker_password(), "");
+			nonce_publisher = getExistingOrNewBrokerPublisher(GET_USER_TOPIC,processorPropertiesStatic.getNebulous_broker_ip_address(), processorPropertiesStatic.getNebulous_broker_port(), processorPropertiesStatic.getNebulous_broker_username(), processorPropertiesStatic.getNebulous_broker_password(), "");
 
 			nonce_subscriber = new BrokerSubscriber(GET_USER_TOPIC+".>",processorPropertiesStatic.getNebulous_broker_ip_address(), processorPropertiesStatic.getNebulous_broker_port(), processorPropertiesStatic.getNebulous_broker_username(),processorPropertiesStatic.getNebulous_broker_password(), "","");
 


### PR DESCRIPTION
* RD: Added device-view.html for viewing and editing device details. Fixed and improved devices.html. Modified DeviceManagementController so that the '/monitor/device' endpoint returns the devices of the current user, and also plain users can retrieve info for the devices they own.

* RD: Moved 'metrics' section side-by-side to 'device info' section in device-view.html, for better viewing

* RD: changed mongo db name to 'resource_discovery' in application.yml

* RD: Minor GUI improvements

* RD: Added DeviceMonitorService to watch the status updates from EMS. Added DeviceStatusUpdate class used in DeviceMonitorService, and added field statusUpdate in Device class. Restructured and improved ResourceDiscoveryProperties.

* RD: Created AbstractMonitorService (to factor out common topic monitoring code). Renamed DeviceMonitorService to DeviceStatusMonitorService and made it subclass of AbstractMonitorService. Changed DeviceStatusUpdate class to ignore unknown properties during deserialization.

* RD: Added banner

* RD: Added DeviceMetricsMonitorService and DeviceMetrics classes. Updated Device class to store device metrics received from EMS

* RD: Updated application.yml

* RD: Added device metrics display in device-view.html. Added (EMS) device status in devices.html

* RD: Updated device-view.html to display device metrics

* RD: Modified Device in monitoring subsystem to not have its credentials serialized (and returned to browser). Also updated the affected code

* RD: Added check for a request's device IP address being in use (in another request or a registered device)

* RD: various minor code improvements

* RD: Added better error reporting in request-edit.html

* RD: Various small GUI improvements and a fix

* RD: Fixed registration Device in order toString() not to print credentials. Fixed RegistrationRequest in order to have its 'messages' and 'history' fields copied by BeanUtils. Fixed 2 bugs in RegistrationRequestProcessor and added a few more logs.

* RD: Minor change in device-view.html to move 'count-' metrics to the end of the device metrics list

* RD: Changed monitoring Device to not serialize credentials

* RD: Code cleanup in RegistrationRequestProcessor

* RD: Improved GUI (added page shortcuts at top-right)

* RD: Implementing re-onboarding, off-boarding, and request-for-info (device status and metrics) [WIP]

* RD: Added DeviceLifeCycleRequestService and DeviceLifeCycleResponseService classes for handling reinstall and uninstall actions (via EMS broker). Moved LC request event sending from DeviceManagementService to DeviceLifeCycleRequestService. Updated ResourceDiscoveryProperties with settings for DeviceLifeCycleRequest/ResponseService's.

* RD: Added device archiving and unarchiving in GUI

* RD: Implemented DeviceProcessor to periodically archive off-boarded devices. Added configurable immediate archiving of Success registration requests, and off-boarded devices, and added relevant settings in ResourceDiscoveryProperties  and in GUI.

* RD: Changed devices.html to always display 'Archive' button to Admin users

* RD: Added archived-device-view.html, renamed archived-view.html to archived-request-view.html. Updated archived.html

* RD: Fixed DeviceManagementController to allow plain users (device owners) to access their device info (and archived devices), and control re-installing and off-boarding. Added device colouring based on their status.

* RD: Extended DeviceProcessor to check for suspect and failed devices. Added SUSPECT and FAILED statues in DeviceStatus (and in devices.html and archived.html for colouring). Added relevant settings in ResourceDiscoveryProperties. Fixed a few naming errors.

* RD: Added shortcuts (top-right corner) to all detail pages

* RD: Minor change in index.html (grayed out settings image)

* RD: Improved AbstractMonitorService (reuse of single connection, better logs). Updated affected code.

* RD: Minor code (mostly logging) and GUI improvements

* RD: Added 'UnknownDeviceRegistrationService' class to monitor for unknown devices (based on IP address and reference in messages received from EMS), and registering them to RD. Added NODE_DETAILS in REQUEST_TYPE enum for messages sent to/received from EMS about acquiring detailed node info (including credentials). Added 'deviceInfoRequestsTopic' and 'deviceInfoReportsTopic' settings in ResourceDiscoveryProperties.

* RD: Added prompting admin to provide device credentials when un-archiving a previously archived request or device.

* RD: Moved REQUEST_TYPE enum to 'common' package and updated code

* RD: Changed authentication to use BCrypt-encrypted passwords

* RD: Moved message broker communication code to BrokerUtil class, and updated using classes accordingly. Implemented EncryptionUtil for encrypting and decrypting broker messages [TO BE TESTED]. Few minor code improvements.

* RD: Minor code tidy up

* RD: Added support for SSL connections to ActiveMQ broker in BrokerUtil. Added the needed settings in ResourceDiscoveryProperties and application.yml

* RD: Fixed issue where UnknownDeviceRegistrationService registers a device before RegistrationRequestProcessor does

* RD: Modified pom.xml to build an image named 'eu.nebulous.resource-discovery' and tagged with current project version

* RD: Added 'DeviceLocation' class and 'location' field in both 'Device' classes. Also updated all 4 details pages to include Location (name, lat, lon). Fixed the Restore button of the modal dialog in archived.html to display 'Restore Request' or 'Restore Device' depending on the restore type.

* RD: Added StatusController to report current application status (currently returns 'OK')

* RD: Fixed a few minor issues:
* Fixed 'spring.web.resources.static-locations'
* Changed Docker image name to 'resource-discovery'
* Set BPE_LANG value to C.UTF-8 in order to render banner correctly

* RD: Changes in pom.xml and application.yml:
* Changed groupId in pom.xml to 'eu.nebulous.resource-management', and artifactId to 'resource-discovery'
* Corrected service name and description
* Set 'imageName' property to derive from artifactId
* Fixed application.yml to use '@project.version@' placeholder for app version

* RD: Renamed 'management' module to 'resource-discovery'

* RD:
* Commented out Buildpacks related settings in pom.xml
* Added Dockerfile, run.sh (entrypoint script) and .dockerignore

* RD: Modified base images in Dockerfile

* RD: Modified Dockerfile in order to both compile the app and build the Docker image

* RD: Improved Dockerfile

* RD: Improved Dockerfile

* RD: Upgraded SB version to SB 3.2.1 and JRE to version 21. Updated dependency to their latest versions. Modified model classes to avoid Lombok SuperBuilder warnings.

* RD: Fixed Dockerfile

* Initial changes to support registration and deregistration of edge devices to SAL

Introduction of Broker publisher and subscriber utilities Introduction of new device registration service

I94a6fdb4612de192c24511445f1236cdce94b000

* EMS: Added K8sNetdataCollector [WIP]

* RD: Added 'port' in forms and models

* RD: Added two TODOs

* RD: Deactivated UnknownDeviceRegistrationService

* Initial changes to support registration and deregistration of edge devices to SAL

Introduction of Broker publisher and subscriber utilities Introduction of new device registration service

I94a6fdb4612de192c24511445f1236cdce94b000

* Improvement in the initialization of SALRegistrationService I94a6fdb4612de192c24511445f1236cdce94b000

* Improvement in the initialization of SALRegistrationService I94a6fdb4612de192c24511445f1236cdce94b000

* Increased logging to debug setting of processorProperties I94a6fdb4612de192c24511445f1236cdce94b000

* Modified logging to debug the setting of processorProperties I94a6fdb4612de192c24511445f1236cdce94b000

* Correction of syntactic error I94a6fdb4612de192c24511445f1236cdce94b000

* Addition of needed configuration properties I94a6fdb4612de192c24511445f1236cdce94b000

* Testing of alternative initialization of SAL registration service I94a6fdb4612de192c24511445f1236cdce94b000

* Testing of alternative initialization of SAL registration service I94a6fdb4612de192c24511445f1236cdce94b000

* Updates on the topic and the payload format used to communicate with SAL for the registration of a device I94a6fdb4612de192c24511445f1236cdce94b000

* Allow setting and using a custom broker port I94a6fdb4612de192c24511445f1236cdce94b000

* Pass a default port to the configuration of the Resource discovery server I94a6fdb4612de192c24511445f1236cdce94b000

* Log debugging information related to the port of the NebulOuS broker I94a6fdb4612de192c24511445f1236cdce94b000

* Publishing of the appropriate message to the broker I94a6fdb4612de192c24511445f1236cdce94b000

* RD: Removed truststore settings from application.yml. Upgraded to SB 3.2.4 and fixed pom.xml

* RD: Fixed banner.txt

* RD: Modified application.yml

* RD: Added temp. debug messages

* RD: Added temp. debug messages 2

* Revert "RD: Added temp. debug messages 2"

This reverts commit 738f6048a8b88b4cfc7410db2146c7d7855c03bd.

* Revert "RD: Added temp. debug messages"

This reverts commit 31b103c207dd900689c94fe5b608a0a03db8fc80.

* RD: Modified SALRegistrationService to run SAL registration in dedicated worker thread, and interrupt registration if it takes too long. Added related settings and assigned defaults.

* RD: Added temp. log messages

* Revert "RD: Added temp. log messages"

This reverts commit 2dae6582de0359a4f33b0d8c066b1b55ecad2227.

* RD: Updated DeviceMetricsMonitorService to match metric events to device using first the IP address and the client Id (stored in Device.StatusUpdate)

* Improvements on edge device data propagation I94a6fdb4612de192c24511445f1236cdce94b000

* Integration of changes performed in commit e3bd3852 but accidentally overriden I94a6fdb4612de192c24511445f1236cdce94b000

* RD: Updated Dockerfile

* RD: Updated run.sh and added wait_for_mongodb.sh

* RD: Improved wait_for_mongodb.sh script

* Various Improvements Addition of the port attribute in the registration of an edge device Modification of the edge device registration to allow for more dynamic registration json field population I94a6fdb4612de192c24511445f1236cdce94b000

* Attempt to fix a problem when publishing to the broker to register information to SAL or notify the SLO Violation detector I94a6fdb4612de192c24511445f1236cdce94b000

* Miscellaneous improvements

Updated the registration of architecture/jar files for each edge device registered

Preliminary work to support 'Compromised state'

* RD: Added API Key authentication

* RD: Upgraded SB to 3.2.10, and Lombok, commons-lang3 dependencies to their latest versions. Improved Dockerfile.

* RD: Code improvements (esp. wrt @PreAuthorize annotations)

* RD: Made SALRegistrationService service conditionally enabled (by 'discovery.sal-registration.enabled' property). Its uses were updated accordingly.

* RD: Updated RegistrationRequestService (and its uses) to take authenticated user into consideration during checks of requests and devices sent from GUI. Also added checks for the device data provided.

* RD: Added 'Device.ref' field and added its initialization. Ref field will be populated with a unique device reference following the Nebulous naming convention (including app id).

* RD: Updated GUI pages to include the new 'ref' field. A few more improvements were introduced.

* Use device reference instead of name to register to SAL

* Improvements in device registration and component communication with the broker

* Small improvements in device registration

* Small improvement in getting device registration details

* Small improvement in getting device registration details

* RD: Fix in SALRegistrationService class

* RD: Fixed fontawesome cdn url

* Initial deregistration support

* RD: Made device on-boarding authorization configurable (MANUAL, ALWAYS_AUTHORIZE, and ALWAYS_REJECT)

* RD: Updated RegistrationRequestProcessor to include Device Ref in onboarding request to EMS

* Improvements in the handling of AMQP connections

* Addition of provider field, miscellaneous improvements

- Addition of provider field in device registration
- Small improvements the Synchronous Broker publisher

* Minor logging improvements

* Deregistration process improvement

* Stopping the device lost publisher

* Refactoring to use the original Connector class instead of ExtendedConnector

* Minor logging improvement

* Only try to stop the connector if it has been previously initialized

* Miscellaneous improvements

Implementation of edge device/byon hourly cost (price) field Only try to stop the connector if it has been previously initialized

* Password improvements

Removal of plaintext passwords and replacement with environmental variable values

* Debugging message commit

* Work on Deregistration support

* Added more logging statements to debug device registration (work by ipatini)

* Fix parsing the json response of SAL

* Changes to avoid stopping the connector

* Sal response parsing improvement and other improvements (#35)

* Debugging message (#32)

* RD: Added device-view.html for viewing and editing device details. Fixed and improved devices.html. Modified DeviceManagementController so that the '/monitor/device' endpoint returns the devices of the current user, and also plain users can retrieve info for the devices they own.

* RD: Moved 'metrics' section side-by-side to 'device info' section in device-view.html, for better viewing

* RD: changed mongo db name to 'resource_discovery' in application.yml

* RD: Minor GUI improvements

* RD: Added DeviceMonitorService to watch the status updates from EMS. Added DeviceStatusUpdate class used in DeviceMonitorService, and added field statusUpdate in Device class. Restructured and improved ResourceDiscoveryProperties.

* RD: Created AbstractMonitorService (to factor out common topic monitoring code). Renamed DeviceMonitorService to DeviceStatusMonitorService and made it subclass of AbstractMonitorService. Changed DeviceStatusUpdate class to ignore unknown properties during deserialization.

* RD: Added banner

* RD: Added DeviceMetricsMonitorService and DeviceMetrics classes. Updated Device class to store device metrics received from EMS

* RD: Updated application.yml

* RD: Added device metrics display in device-view.html. Added (EMS) device status in devices.html

* RD: Updated device-view.html to display device metrics

* RD: Modified Device in monitoring subsystem to not have its credentials serialized (and returned to browser). Also updated the affected code

* RD: Added check for a request's device IP address being in use (in another request or a registered device)

* RD: various minor code improvements

* RD: Added better error reporting in request-edit.html

* RD: Various small GUI improvements and a fix

* RD: Fixed registration Device in order toString() not to print credentials. Fixed RegistrationRequest in order to have its 'messages' and 'history' fields copied by BeanUtils. Fixed 2 bugs in RegistrationRequestProcessor and added a few more logs.

* RD: Minor change in device-view.html to move 'count-' metrics to the end of the device metrics list

* RD: Changed monitoring Device to not serialize credentials

* RD: Code cleanup in RegistrationRequestProcessor

* RD: Improved GUI (added page shortcuts at top-right)

* RD: Implementing re-onboarding, off-boarding, and request-for-info (device status and metrics) [WIP]

* RD: Added DeviceLifeCycleRequestService and DeviceLifeCycleResponseService classes for handling reinstall and uninstall actions (via EMS broker). Moved LC request event sending from DeviceManagementService to DeviceLifeCycleRequestService. Updated ResourceDiscoveryProperties with settings for DeviceLifeCycleRequest/ResponseService's.

* RD: Added device archiving and unarchiving in GUI

* RD: Implemented DeviceProcessor to periodically archive off-boarded devices. Added configurable immediate archiving of Success registration requests, and off-boarded devices, and added relevant settings in ResourceDiscoveryProperties  and in GUI.

* RD: Changed devices.html to always display 'Archive' button to Admin users

* RD: Added archived-device-view.html, renamed archived-view.html to archived-request-view.html. Updated archived.html

* RD: Fixed DeviceManagementController to allow plain users (device owners) to access their device info (and archived devices), and control re-installing and off-boarding. Added device colouring based on their status.

* RD: Extended DeviceProcessor to check for suspect and failed devices. Added SUSPECT and FAILED statues in DeviceStatus (and in devices.html and archived.html for colouring). Added relevant settings in ResourceDiscoveryProperties. Fixed a few naming errors.

* RD: Added shortcuts (top-right corner) to all detail pages

* RD: Minor change in index.html (grayed out settings image)

* RD: Improved AbstractMonitorService (reuse of single connection, better logs). Updated affected code.

* RD: Minor code (mostly logging) and GUI improvements

* RD: Added 'UnknownDeviceRegistrationService' class to monitor for unknown devices (based on IP address and reference in messages received from EMS), and registering them to RD. Added NODE_DETAILS in REQUEST_TYPE enum for messages sent to/received from EMS about acquiring detailed node info (including credentials). Added 'deviceInfoRequestsTopic' and 'deviceInfoReportsTopic' settings in ResourceDiscoveryProperties.

* RD: Added prompting admin to provide device credentials when un-archiving a previously archived request or device.

* RD: Moved REQUEST_TYPE enum to 'common' package and updated code

* RD: Changed authentication to use BCrypt-encrypted passwords

* RD: Moved message broker communication code to BrokerUtil class, and updated using classes accordingly. Implemented EncryptionUtil for encrypting and decrypting broker messages [TO BE TESTED]. Few minor code improvements.

* RD: Minor code tidy up

* RD: Added support for SSL connections to ActiveMQ broker in BrokerUtil. Added the needed settings in ResourceDiscoveryProperties and application.yml

* RD: Fixed issue where UnknownDeviceRegistrationService registers a device before RegistrationRequestProcessor does

* RD: Modified pom.xml to build an image named 'eu.nebulous.resource-discovery' and tagged with current project version

* RD: Added 'DeviceLocation' class and 'location' field in both 'Device' classes. Also updated all 4 details pages to include Location (name, lat, lon). Fixed the Restore button of the modal dialog in archived.html to display 'Restore Request' or 'Restore Device' depending on the restore type.

* RD: Added StatusController to report current application status (currently returns 'OK')

* RD: Fixed a few minor issues:
* Fixed 'spring.web.resources.static-locations'
* Changed Docker image name to 'resource-discovery'
* Set BPE_LANG value to C.UTF-8 in order to render banner correctly

* RD: Changes in pom.xml and application.yml:
* Changed groupId in pom.xml to 'eu.nebulous.resource-management', and artifactId to 'resource-discovery'
* Corrected service name and description
* Set 'imageName' property to derive from artifactId
* Fixed application.yml to use '@project.version@' placeholder for app version

* RD: Renamed 'management' module to 'resource-discovery'

* RD:
* Commented out Buildpacks related settings in pom.xml
* Added Dockerfile, run.sh (entrypoint script) and .dockerignore

* RD: Modified base images in Dockerfile

* RD: Modified Dockerfile in order to both compile the app and build the Docker image

* RD: Improved Dockerfile

* RD: Improved Dockerfile

* RD: Upgraded SB version to SB 3.2.1 and JRE to version 21. Updated dependency to their latest versions. Modified model classes to avoid Lombok SuperBuilder warnings.

* RD: Fixed Dockerfile

* Initial changes to support registration and deregistration of edge devices to SAL

Introduction of Broker publisher and subscriber utilities Introduction of new device registration service

I94a6fdb4612de192c24511445f1236cdce94b000

* EMS: Added K8sNetdataCollector [WIP]

* RD: Added 'port' in forms and models

* RD: Added two TODOs

* RD: Deactivated UnknownDeviceRegistrationService

* Initial changes to support registration and deregistration of edge devices to SAL

Introduction of Broker publisher and subscriber utilities Introduction of new device registration service

I94a6fdb4612de192c24511445f1236cdce94b000

* Improvement in the initialization of SALRegistrationService I94a6fdb4612de192c24511445f1236cdce94b000

* Improvement in the initialization of SALRegistrationService I94a6fdb4612de192c24511445f1236cdce94b000

* Increased logging to debug setting of processorProperties I94a6fdb4612de192c24511445f1236cdce94b000

* Modified logging to debug the setting of processorProperties I94a6fdb4612de192c24511445f1236cdce94b000

* Correction of syntactic error I94a6fdb4612de192c24511445f1236cdce94b000

* Addition of needed configuration properties I94a6fdb4612de192c24511445f1236cdce94b000

* Testing of alternative initialization of SAL registration service I94a6fdb4612de192c24511445f1236cdce94b000

* Testing of alternative initialization of SAL registration service I94a6fdb4612de192c24511445f1236cdce94b000

* Updates on the topic and the payload format used to communicate with SAL for the registration of a device I94a6fdb4612de192c24511445f1236cdce94b000

* Allow setting and using a custom broker port I94a6fdb4612de192c24511445f1236cdce94b000

* Pass a default port to the configuration of the Resource discovery server I94a6fdb4612de192c24511445f1236cdce94b000

* Log debugging information related to the port of the NebulOuS broker I94a6fdb4612de192c24511445f1236cdce94b000

* Publishing of the appropriate message to the broker I94a6fdb4612de192c24511445f1236cdce94b000

* RD: Removed truststore settings from application.yml. Upgraded to SB 3.2.4 and fixed pom.xml

* RD: Fixed banner.txt

* RD: Modified application.yml

* RD: Added temp. debug messages

* RD: Added temp. debug messages 2

* Revert "RD: Added temp. debug messages 2"

This reverts commit 738f6048a8b88b4cfc7410db2146c7d7855c03bd.

* Revert "RD: Added temp. debug messages"

This reverts commit 31b103c207dd900689c94fe5b608a0a03db8fc80.

* RD: Modified SALRegistrationService to run SAL registration in dedicated worker thread, and interrupt registration if it takes too long. Added related settings and assigned defaults.

* RD: Added temp. log messages

* Revert "RD: Added temp. log messages"

This reverts commit 2dae6582de0359a4f33b0d8c066b1b55ecad2227.

* RD: Updated DeviceMetricsMonitorService to match metric events to device using first the IP address and the client Id (stored in Device.StatusUpdate)

* Improvements on edge device data propagation I94a6fdb4612de192c24511445f1236cdce94b000

* Integration of changes performed in commit e3bd3852 but accidentally overriden I94a6fdb4612de192c24511445f1236cdce94b000

* RD: Updated Dockerfile

* RD: Updated run.sh and added wait_for_mongodb.sh

* RD: Improved wait_for_mongodb.sh script

* Various Improvements Addition of the port attribute in the registration of an edge device Modification of the edge device registration to allow for more dynamic registration json field population I94a6fdb4612de192c24511445f1236cdce94b000

* Attempt to fix a problem when publishing to the broker to register information to SAL or notify the SLO Violation detector I94a6fdb4612de192c24511445f1236cdce94b000

* Miscellaneous improvements

Updated the registration of architecture/jar files for each edge device registered

Preliminary work to support 'Compromised state'

* RD: Added API Key authentication

* RD: Upgraded SB to 3.2.10, and Lombok, commons-lang3 dependencies to their latest versions. Improved Dockerfile.

* RD: Code improvements (esp. wrt @PreAuthorize annotations)

* RD: Made SALRegistrationService service conditionally enabled (by 'discovery.sal-registration.enabled' property). Its uses were updated accordingly.

* RD: Updated RegistrationRequestService (and its uses) to take authenticated user into consideration during checks of requests and devices sent from GUI. Also added checks for the device data provided.

* RD: Added 'Device.ref' field and added its initialization. Ref field will be populated with a unique device reference following the Nebulous naming convention (including app id).

* RD: Updated GUI pages to include the new 'ref' field. A few more improvements were introduced.

* Use device reference instead of name to register to SAL

* Improvements in device registration and component communication with the broker

* Small improvements in device registration

* Small improvement in getting device registration details

* Small improvement in getting device registration details

* RD: Fix in SALRegistrationService class

* RD: Fixed fontawesome cdn url

* Initial deregistration support

* RD: Made device on-boarding authorization configurable (MANUAL, ALWAYS_AUTHORIZE, and ALWAYS_REJECT)

* RD: Updated RegistrationRequestProcessor to include Device Ref in onboarding request to EMS

* Improvements in the handling of AMQP connections

* Addition of provider field, miscellaneous improvements

- Addition of provider field in device registration
- Small improvements the Synchronous Broker publisher

* Minor logging improvements

* Deregistration process improvement

* Stopping the device lost publisher

* Refactoring to use the original Connector class instead of ExtendedConnector

* Minor logging improvement

* Only try to stop the connector if it has been previously initialized

* Miscellaneous improvements

Implementation of edge device/byon hourly cost (price) field Only try to stop the connector if it has been previously initialized

* Password improvements

Removal of plaintext passwords and replacement with environmental variable values

* Debugging message commit

---------




* Logging improvements (#33)

* RD: Added device-view.html for viewing and editing device details. Fixed and improved devices.html. Modified DeviceManagementController so that the '/monitor/device' endpoint returns the devices of the current user, and also plain users can retrieve info for the devices they own.

* RD: Moved 'metrics' section side-by-side to 'device info' section in device-view.html, for better viewing

* RD: changed mongo db name to 'resource_discovery' in application.yml

* RD: Minor GUI improvements

* RD: Added DeviceMonitorService to watch the status updates from EMS. Added DeviceStatusUpdate class used in DeviceMonitorService, and added field statusUpdate in Device class. Restructured and improved ResourceDiscoveryProperties.

* RD: Created AbstractMonitorService (to factor out common topic monitoring code). Renamed DeviceMonitorService to DeviceStatusMonitorService and made it subclass of AbstractMonitorService. Changed DeviceStatusUpdate class to ignore unknown properties during deserialization.

* RD: Added banner

* RD: Added DeviceMetricsMonitorService and DeviceMetrics classes. Updated Device class to store device metrics received from EMS

* RD: Updated application.yml

* RD: Added device metrics display in device-view.html. Added (EMS) device status in devices.html

* RD: Updated device-view.html to display device metrics

* RD: Modified Device in monitoring subsystem to not have its credentials serialized (and returned to browser). Also updated the affected code

* RD: Added check for a request's device IP address being in use (in another request or a registered device)

* RD: various minor code improvements

* RD: Added better error reporting in request-edit.html

* RD: Various small GUI improvements and a fix

* RD: Fixed registration Device in order toString() not to print credentials. Fixed RegistrationRequest in order to have its 'messages' and 'history' fields copied by BeanUtils. Fixed 2 bugs in RegistrationRequestProcessor and added a few more logs.

* RD: Minor change in device-view.html to move 'count-' metrics to the end of the device metrics list

* RD: Changed monitoring Device to not serialize credentials

* RD: Code cleanup in RegistrationRequestProcessor

* RD: Improved GUI (added page shortcuts at top-right)

* RD: Implementing re-onboarding, off-boarding, and request-for-info (device status and metrics) [WIP]

* RD: Added DeviceLifeCycleRequestService and DeviceLifeCycleResponseService classes for handling reinstall and uninstall actions (via EMS broker). Moved LC request event sending from DeviceManagementService to DeviceLifeCycleRequestService. Updated ResourceDiscoveryProperties with settings for DeviceLifeCycleRequest/ResponseService's.

* RD: Added device archiving and unarchiving in GUI

* RD: Implemented DeviceProcessor to periodically archive off-boarded devices. Added configurable immediate archiving of Success registration requests, and off-boarded devices, and added relevant settings in ResourceDiscoveryProperties  and in GUI.

* RD: Changed devices.html to always display 'Archive' button to Admin users

* RD: Added archived-device-view.html, renamed archived-view.html to archived-request-view.html. Updated archived.html

* RD: Fixed DeviceManagementController to allow plain users (device owners) to access their device info (and archived devices), and control re-installing and off-boarding. Added device colouring based on their status.

* RD: Extended DeviceProcessor to check for suspect and failed devices. Added SUSPECT and FAILED statues in DeviceStatus (and in devices.html and archived.html for colouring). Added relevant settings in ResourceDiscoveryProperties. Fixed a few naming errors.

* RD: Added shortcuts (top-right corner) to all detail pages

* RD: Minor change in index.html (grayed out settings image)

* RD: Improved AbstractMonitorService (reuse of single connection, better logs). Updated affected code.

* RD: Minor code (mostly logging) and GUI improvements

* RD: Added 'UnknownDeviceRegistrationService' class to monitor for unknown devices (based on IP address and reference in messages received from EMS), and registering them to RD. Added NODE_DETAILS in REQUEST_TYPE enum for messages sent to/received from EMS about acquiring detailed node info (including credentials). Added 'deviceInfoRequestsTopic' and 'deviceInfoReportsTopic' settings in ResourceDiscoveryProperties.

* RD: Added prompting admin to provide device credentials when un-archiving a previously archived request or device.

* RD: Moved REQUEST_TYPE enum to 'common' package and updated code

* RD: Changed authentication to use BCrypt-encrypted passwords

* RD: Moved message broker communication code to BrokerUtil class, and updated using classes accordingly. Implemented EncryptionUtil for encrypting and decrypting broker messages [TO BE TESTED]. Few minor code improvements.

* RD: Minor code tidy up

* RD: Added support for SSL connections to ActiveMQ broker in BrokerUtil. Added the needed settings in ResourceDiscoveryProperties and application.yml

* RD: Fixed issue where UnknownDeviceRegistrationService registers a device before RegistrationRequestProcessor does

* RD: Modified pom.xml to build an image named 'eu.nebulous.resource-discovery' and tagged with current project version

* RD: Added 'DeviceLocation' class and 'location' field in both 'Device' classes. Also updated all 4 details pages to include Location (name, lat, lon). Fixed the Restore button of the modal dialog in archived.html to display 'Restore Request' or 'Restore Device' depending on the restore type.

* RD: Added StatusController to report current application status (currently returns 'OK')

* RD: Fixed a few minor issues:
* Fixed 'spring.web.resources.static-locations'
* Changed Docker image name to 'resource-discovery'
* Set BPE_LANG value to C.UTF-8 in order to render banner correctly

* RD: Changes in pom.xml and application.yml:
* Changed groupId in pom.xml to 'eu.nebulous.resource-management', and artifactId to 'resource-discovery'
* Corrected service name and description
* Set 'imageName' property to derive from artifactId
* Fixed application.yml to use '@project.version@' placeholder for app version

* RD: Renamed 'management' module to 'resource-discovery'

* RD:
* Commented out Buildpacks related settings in pom.xml
* Added Dockerfile, run.sh (entrypoint script) and .dockerignore

* RD: Modified base images in Dockerfile

* RD: Modified Dockerfile in order to both compile the app and build the Docker image

* RD: Improved Dockerfile

* RD: Improved Dockerfile

* RD: Upgraded SB version to SB 3.2.1 and JRE to version 21. Updated dependency to their latest versions. Modified model classes to avoid Lombok SuperBuilder warnings.

* RD: Fixed Dockerfile

* Initial changes to support registration and deregistration of edge devices to SAL

Introduction of Broker publisher and subscriber utilities Introduction of new device registration service

I94a6fdb4612de192c24511445f1236cdce94b000

* EMS: Added K8sNetdataCollector [WIP]

* RD: Added 'port' in forms and models

* RD: Added two TODOs

* RD: Deactivated UnknownDeviceRegistrationService

* Initial changes to support registration and deregistration of edge devices to SAL

Introduction of Broker publisher and subscriber utilities Introduction of new device registration service

I94a6fdb4612de192c24511445f1236cdce94b000

* Improvement in the initialization of SALRegistrationService I94a6fdb4612de192c24511445f1236cdce94b000

* Improvement in the initialization of SALRegistrationService I94a6fdb4612de192c24511445f1236cdce94b000

* Increased logging to debug setting of processorProperties I94a6fdb4612de192c24511445f1236cdce94b000

* Modified logging to debug the setting of processorProperties I94a6fdb4612de192c24511445f1236cdce94b000

* Correction of syntactic error I94a6fdb4612de192c24511445f1236cdce94b000

* Addition of needed configuration properties I94a6fdb4612de192c24511445f1236cdce94b000

* Testing of alternative initialization of SAL registration service I94a6fdb4612de192c24511445f1236cdce94b000

* Testing of alternative initialization of SAL registration service I94a6fdb4612de192c24511445f1236cdce94b000

* Updates on the topic and the payload format used to communicate with SAL for the registration of a device I94a6fdb4612de192c24511445f1236cdce94b000

* Allow setting and using a custom broker port I94a6fdb4612de192c24511445f1236cdce94b000

* Pass a default port to the configuration of the Resource discovery server I94a6fdb4612de192c24511445f1236cdce94b000

* Log debugging information related to the port of the NebulOuS broker I94a6fdb4612de192c24511445f1236cdce94b000

* Publishing of the appropriate message to the broker I94a6fdb4612de192c24511445f1236cdce94b000

* RD: Removed truststore settings from application.yml. Upgraded to SB 3.2.4 and fixed pom.xml

* RD: Fixed banner.txt

* RD: Modified application.yml

* RD: Added temp. debug messages

* RD: Added temp. debug messages 2

* Revert "RD: Added temp. debug messages 2"

This reverts commit 738f6048a8b88b4cfc7410db2146c7d7855c03bd.

* Revert "RD: Added temp. debug messages"

This reverts commit 31b103c207dd900689c94fe5b608a0a03db8fc80.

* RD: Modified SALRegistrationService to run SAL registration in dedicated worker thread, and interrupt registration if it takes too long. Added related settings and assigned defaults.

* RD: Added temp. log messages

* Revert "RD: Added temp. log messages"

This reverts commit 2dae6582de0359a4f33b0d8c066b1b55ecad2227.

* RD: Updated DeviceMetricsMonitorService to match metric events to device using first the IP address and the client Id (stored in Device.StatusUpdate)

* Improvements on edge device data propagation I94a6fdb4612de192c24511445f1236cdce94b000

* Integration of changes performed in commit e3bd3852 but accidentally overriden I94a6fdb4612de192c24511445f1236cdce94b000

* RD: Updated Dockerfile

* RD: Updated run.sh and added wait_for_mongodb.sh

* RD: Improved wait_for_mongodb.sh script

* Various Improvements Addition of the port attribute in the registration of an edge device Modification of the edge device registration to allow for more dynamic registration json field population I94a6fdb4612de192c24511445f1236cdce94b000

* Attempt to fix a problem when publishing to the broker to register information to SAL or notify the SLO Violation detector I94a6fdb4612de192c24511445f1236cdce94b000

* Miscellaneous improvements

Updated the registration of architecture/jar files for each edge device registered

Preliminary work to support 'Compromised state'

* RD: Added API Key authentication

* RD: Upgraded SB to 3.2.10, and Lombok, commons-lang3 dependencies to their latest versions. Improved Dockerfile.

* RD: Code improvements (esp. wrt @PreAuthorize annotations)

* RD: Made SALRegistrationService service conditionally enabled (by 'discovery.sal-registration.enabled' property). Its uses were updated accordingly.

* RD: Updated RegistrationRequestService (and its uses) to take authenticated user into consideration during checks of requests and devices sent from GUI. Also added checks for the device data provided.

* RD: Added 'Device.ref' field and added its initialization. Ref field will be populated with a unique device reference following the Nebulous naming convention (including app id).

* RD: Updated GUI pages to include the new 'ref' field. A few more improvements were introduced.

* Use device reference instead of name to register to SAL

* Improvements in device registration and component communication with the broker

* Small improvements in device registration

* Small improvement in getting device registration details

* Small improvement in getting device registration details

* RD: Fix in SALRegistrationService class

* RD: Fixed fontawesome cdn url

* Initial deregistration support

* RD: Made device on-boarding authorization configurable (MANUAL, ALWAYS_AUTHORIZE, and ALWAYS_REJECT)

* RD: Updated RegistrationRequestProcessor to include Device Ref in onboarding request to EMS

* Improvements in the handling of AMQP connections

* Addition of provider field, miscellaneous improvements

- Addition of provider field in device registration
- Small improvements the Synchronous Broker publisher

* Minor logging improvements

* Deregistration process improvement

* Stopping the device lost publisher

* Refactoring to use the original Connector class instead of ExtendedConnector

* Minor logging improvement

* Only try to stop the connector if it has been previously initialized

* Miscellaneous improvements

Implementation of edge device/byon hourly cost (price) field Only try to stop the connector if it has been previously initialized

* Password improvements

Removal of plaintext passwords and replacement with environmental variable values

* Debugging message commit

* Work on Deregistration support

* Added more logging statements to debug device registration (work by ipatini)

---------




* Sal response parsing improvement (#34)

* RD: Added device-view.html for viewing and editing device details. Fixed and improved devices.html. Modified DeviceManagementController so that the '/monitor/device' endpoint returns the devices of the current user, and also plain users can retrieve info for the devices they own.

* RD: Moved 'metrics' section side-by-side to 'device info' section in device-view.html, for better viewing

* RD: changed mongo db name to 'resource_discovery' in application.yml

* RD: Minor GUI improvements

* RD: Added DeviceMonitorService to watch the status updates from EMS. Added DeviceStatusUpdate class used in DeviceMonitorService, and added field statusUpdate in Device class. Restructured and improved ResourceDiscoveryProperties.

* RD: Created AbstractMonitorService (to factor out common topic monitoring code). Renamed DeviceMonitorService to DeviceStatusMonitorService and made it subclass of AbstractMonitorService. Changed DeviceStatusUpdate class to ignore unknown properties during deserialization.

* RD: Added banner

* RD: Added DeviceMetricsMonitorService and DeviceMetrics classes. Updated Device class to store device metrics received from EMS

* RD: Updated application.yml

* RD: Added device metrics display in device-view.html. Added (EMS) device status in devices.html

* RD: Updated device-view.html to display device metrics

* RD: Modified Device in monitoring subsystem to not have its credentials serialized (and returned to browser). Also updated the affected code

* RD: Added check for a request's device IP address being in use (in another request or a registered device)

* RD: various minor code improvements

* RD: Added better error reporting in request-edit.html

* RD: Various small GUI improvements and a fix

* RD: Fixed registration Device in order toString() not to print credentials. Fixed RegistrationRequest in order to have its 'messages' and 'history' fields copied by BeanUtils. Fixed 2 bugs in RegistrationRequestProcessor and added a few more logs.

* RD: Minor change in device-view.html to move 'count-' metrics to the end of the device metrics list

* RD: Changed monitoring Device to not serialize credentials

* RD: Code cleanup in RegistrationRequestProcessor

* RD: Improved GUI (added page shortcuts at top-right)

* RD: Implementing re-onboarding, off-boarding, and request-for-info (device status and metrics) [WIP]

* RD: Added DeviceLifeCycleRequestService and DeviceLifeCycleResponseService classes for handling reinstall and uninstall actions (via EMS broker). Moved LC request event sending from DeviceManagementService to DeviceLifeCycleRequestService. Updated ResourceDiscoveryProperties with settings for DeviceLifeCycleRequest/ResponseService's.

* RD: Added device archiving and unarchiving in GUI

* RD: Implemented DeviceProcessor to periodically archive off-boarded devices. Added configurable immediate archiving of Success registration requests, and off-boarded devices, and added relevant settings in ResourceDiscoveryProperties  and in GUI.

* RD: Changed devices.html to always display 'Archive' button to Admin users

* RD: Added archived-device-view.html, renamed archived-view.html to archived-request-view.html. Updated archived.html

* RD: Fixed DeviceManagementController to allow plain users (device owners) to access their device info (and archived devices), and control re-installing and off-boarding. Added device colouring based on their status.

* RD: Extended DeviceProcessor to check for suspect and failed devices. Added SUSPECT and FAILED statues in DeviceStatus (and in devices.html and archived.html for colouring). Added relevant settings in ResourceDiscoveryProperties. Fixed a few naming errors.

* RD: Added shortcuts (top-right corner) to all detail pages

* RD: Minor change in index.html (grayed out settings image)

* RD: Improved AbstractMonitorService (reuse of single connection, better logs). Updated affected code.

* RD: Minor code (mostly logging) and GUI improvements

* RD: Added 'UnknownDeviceRegistrationService' class to monitor for unknown devices (based on IP address and reference in messages received from EMS), and registering them to RD. Added NODE_DETAILS in REQUEST_TYPE enum for messages sent to/received from EMS about acquiring detailed node info (including credentials). Added 'deviceInfoRequestsTopic' and 'deviceInfoReportsTopic' settings in ResourceDiscoveryProperties.

* RD: Added prompting admin to provide device credentials when un-archiving a previously archived request or device.

* RD: Moved REQUEST_TYPE enum to 'common' package and updated code

* RD: Changed authentication to use BCrypt-encrypted passwords

* RD: Moved message broker communication code to BrokerUtil class, and updated using classes accordingly. Implemented EncryptionUtil for encrypting and decrypting broker messages [TO BE TESTED]. Few minor code improvements.

* RD: Minor code tidy up

* RD: Added support for SSL connections to ActiveMQ broker in BrokerUtil. Added the needed settings in ResourceDiscoveryProperties and application.yml

* RD: Fixed issue where UnknownDeviceRegistrationService registers a device before RegistrationRequestProcessor does

* RD: Modified pom.xml to build an image named 'eu.nebulous.resource-discovery' and tagged with current project version

* RD: Added 'DeviceLocation' class and 'location' field in both 'Device' classes. Also updated all 4 details pages to include Location (name, lat, lon). Fixed the Restore button of the modal dialog in archived.html to display 'Restore Request' or 'Restore Device' depending on the restore type.

* RD: Added StatusController to report current application status (currently returns 'OK')

* RD: Fixed a few minor issues:
* Fixed 'spring.web.resources.static-locations'
* Changed Docker image name to 'resource-discovery'
* Set BPE_LANG value to C.UTF-8 in order to render banner correctly

* RD: Changes in pom.xml and application.yml:
* Changed groupId in pom.xml to 'eu.nebulous.resource-management', and artifactId to 'resource-discovery'
* Corrected service name and description
* Set 'imageName' property to derive from artifactId
* Fixed application.yml to use '@project.version@' placeholder for app version

* RD: Renamed 'management' module to 'resource-discovery'

* RD:
* Commented out Buildpacks related settings in pom.xml
* Added Dockerfile, run.sh (entrypoint script) and .dockerignore

* RD: Modified base images in Dockerfile

* RD: Modified Dockerfile in order to both compile the app and build the Docker image

* RD: Improved Dockerfile

* RD: Improved Dockerfile

* RD: Upgraded SB version to SB 3.2.1 and JRE to version 21. Updated dependency to their latest versions. Modified model classes to avoid Lombok SuperBuilder warnings.

* RD: Fixed Dockerfile

* Initial changes to support registration and deregistration of edge devices to SAL

Introduction of Broker publisher and subscriber utilities Introduction of new device registration service

I94a6fdb4612de192c24511445f1236cdce94b000

* EMS: Added K8sNetdataCollector [WIP]

* RD: Added 'port' in forms and models

* RD: Added two TODOs

* RD: Deactivated UnknownDeviceRegistrationService

* Initial changes to support registration and deregistration of edge devices to SAL

Introduction of Broker publisher and subscriber utilities Introduction of new device registration service

I94a6fdb4612de192c24511445f1236cdce94b000

* Improvement in the initialization of SALRegistrationService I94a6fdb4612de192c24511445f1236cdce94b000

* Improvement in the initialization of SALRegistrationService I94a6fdb4612de192c24511445f1236cdce94b000

* Increased logging to debug setting of processorProperties I94a6fdb4612de192c24511445f1236cdce94b000

* Modified logging to debug the setting of processorProperties I94a6fdb4612de192c24511445f1236cdce94b000

* Correction of syntactic error I94a6fdb4612de192c24511445f1236cdce94b000

* Addition of needed configuration properties I94a6fdb4612de192c24511445f1236cdce94b000

* Testing of alternative initialization of SAL registration service I94a6fdb4612de192c24511445f1236cdce94b000

* Testing of alternative initialization of SAL registration service I94a6fdb4612de192c24511445f1236cdce94b000

* Updates on the topic and the payload format used to communicate with SAL for the registration of a device I94a6fdb4612de192c24511445f1236cdce94b000

* Allow setting and using a custom broker port I94a6fdb4612de192c24511445f1236cdce94b000

* Pass a default port to the configuration of the Resource discovery server I94a6fdb4612de192c24511445f1236cdce94b000

* Log debugging information related to the port of the NebulOuS broker I94a6fdb4612de192c24511445f1236cdce94b000

* Publishing of the appropriate message to the broker I94a6fdb4612de192c24511445f1236cdce94b000

* RD: Removed truststore settings from application.yml. Upgraded to SB 3.2.4 and fixed pom.xml

* RD: Fixed banner.txt

* RD: Modified application.yml

* RD: Added temp. debug messages

* RD: Added temp. debug messages 2

* Revert "RD: Added temp. debug messages 2"

This reverts commit 738f6048a8b88b4cfc7410db2146c7d7855c03bd.

* Revert "RD: Added temp. debug messages"

This reverts commit 31b103c207dd900689c94fe5b608a0a03db8fc80.

* RD: Modified SALRegistrationService to run SAL registration in dedicated worker thread, and interrupt registration if it takes too long. Added related settings and assigned defaults.

* RD: Added temp. log messages

* Revert "RD: Added temp. log messages"

This reverts commit 2dae6582de0359a4f33b0d8c066b1b55ecad2227.

* RD: Updated DeviceMetricsMonitorService to match metric events to device using first the IP address and the client Id (stored in Device.StatusUpdate)

* Improvements on edge device data propagation I94a6fdb4612de192c24511445f1236cdce94b000

* Integration of changes performed in commit e3bd3852 but accidentally overriden I94a6fdb4612de192c24511445f1236cdce94b000

* RD: Updated Dockerfile

* RD: Updated run.sh and added wait_for_mongodb.sh

* RD: Improved wait_for_mongodb.sh script

* Various Improvements Addition of the port attribute in the registration of an edge device Modification of the edge device registration to allow for more dynamic registration json field population I94a6fdb4612de192c24511445f1236cdce94b000

* Attempt to fix a problem when publishing to the broker to register information to SAL or notify the SLO Violation detector I94a6fdb4612de192c24511445f1236cdce94b000

* Miscellaneous improvements

Updated the registration of architecture/jar files for each edge device registered

Preliminary work to support 'Compromised state'

* RD: Added API Key authentication

* RD: Upgraded SB to 3.2.10, and Lombok, commons-lang3 dependencies to their latest versions. Improved Dockerfile.

* RD: Code improvements (esp. wrt @PreAuthorize annotations)

* RD: Made SALRegistrationService service conditionally enabled (by 'discovery.sal-registration.enabled' property). Its uses were updated accordingly.

* RD: Updated RegistrationRequestService (and its uses) to take authenticated user into consideration during checks of requests and devices sent from GUI. Also added checks for the device data provided.

* RD: Added 'Device.ref' field and added its initialization. Ref field will be populated with a unique device reference following the Nebulous naming convention (including app id).

* RD: Updated GUI pages to include the new 'ref' field. A few more improvements were introduced.

* Use device reference instead of name to register to SAL

* Improvements in device registration and component communication with the broker

* Small improvements in device registration

* Small improvement in getting device registration details

* Small improvement in getting device registration details

* RD: Fix in SALRegistrationService class

* RD: Fixed fontawesome cdn url

* Initial deregistration support

* RD: Made device on-boarding authorization configurable (MANUAL, ALWAYS_AUTHORIZE, and ALWAYS_REJECT)

* RD: Updated RegistrationRequestProcessor to include Device Ref in onboarding request to EMS

* Improvements in the handling of AMQP connections

* Addition of provider field, miscellaneous improvements

- Addition of provider field in device registration
- Small improvements the Synchronous Broker publisher

* Minor logging improvements

* Deregistration process improvement

* Stopping the device lost publisher

* Refactoring to use the original Connector class instead of ExtendedConnector

* Minor logging improvement

* Only try to stop the connector if it has been previously initialized

* Miscellaneous improvements

Implementation of edge device/byon hourly cost (price) field Only try to stop the connector if it has been previously initialized

* Password improvements

Removal of plaintext passwords and replacement with environmental variable values

* Debugging message commit

* Work on Deregistration support

* Added more logging statements to debug device registration (work by ipatini)

* Fix parsing the json response of SAL

---------




* Avoid publish connector stop (#36)

* RD: Added device-view.html for viewing and editing device details. Fixed and improved devices.html. Modified DeviceManagementController so that the '/monitor/device' endpoint returns the devices of the current user, and also plain users can retrieve info for the devices they own.

* RD: Moved 'metrics' section side-by-side to 'device info' section in device-view.html, for better viewing

* RD: changed mongo db name to 'resource_discovery' in application.yml

* RD: Minor GUI improvements

* RD: Added DeviceMonitorService to watch the status updates from EMS. Added DeviceStatusUpdate class used in DeviceMonitorService, and added field statusUpdate in Device class. Restructured and improved ResourceDiscoveryProperties.

* RD: Created AbstractMonitorService (to factor out common topic monitoring code). Renamed DeviceMonitorService to DeviceStatusMonitorService and made it subclass of AbstractMonitorService. Changed DeviceStatusUpdate class to ignore unknown properties during deserialization.

* RD: Added banner

* RD: Added DeviceMetricsMonitorService and DeviceMetrics classes. Updated Device class to store device metrics received from EMS

* RD: Updated application.yml

* RD: Added device metrics display in device-view.html. Added (EMS) device status in devices.html

* RD: Updated device-view.html to display device metrics

* RD: Modified Device in monitoring subsystem to not have its credentials serialized (and returned to browser). Also updated the affected code

* RD: Added check for a request's device IP address being in use (in another request or a registered device)

* RD: various minor code improvements

* RD: Added better error reporting in request-edit.html

* RD: Various small GUI improvements and a fix

* RD: Fixed registration Device in order toString() not to print credentials. Fixed RegistrationRequest in order to have its 'messages' and 'history' fields copied by BeanUtils. Fixed 2 bugs in RegistrationRequestProcessor and added a few more logs.

* RD: Minor change in device-view.html to move 'count-' metrics to the end of the device metrics list

* RD: Changed monitoring Device to not serialize credentials

* RD: Code cleanup in RegistrationRequestProcessor

* RD: Improved GUI (added page shortcuts at top-right)

* RD: Implementing re-onboarding, off-boarding, and request-for-info (device status and metrics) [WIP]

* RD: Added DeviceLifeCycleRequestService and DeviceLifeCycleResponseService classes for handling reinstall and uninstall actions (via EMS broker). Moved LC request event sending from DeviceManagementService to DeviceLifeCycleRequestService. Updated ResourceDiscoveryProperties with settings for DeviceLifeCycleRequest/ResponseService's.

* RD: Added device archiving and unarchiving in GUI

* RD: Implemented DeviceProcessor to periodically archive off-boarded devices. Added configurable immediate archiving of Success registration requests, and off-boarded devices, and added relevant settings in ResourceDiscoveryProperties  and in GUI.

* RD: Changed devices.html to always display 'Archive' button to Admin users

* RD: Added archived-device-view.html, renamed archived-view.html to archived-request-view.html. Updated archived.html

* RD: Fixed DeviceManagementController to allow plain users (device owners) to access their device info (and archived devices), and control re-installing and off-boarding. Added device colouring based on their status.

* RD: Extended DeviceProcessor to check for suspect and failed devices. Added SUSPECT and FAILED statues in DeviceStatus (and in devices.html and archived.html for colouring). Added relevant settings in ResourceDiscoveryProperties. Fixed a few naming errors.

* RD: Added shortcuts (top-right corner) to all detail pages

* RD: Minor change in index.html (grayed out settings image)

* RD: Improved AbstractMonitorService (reuse of single connection, better logs). Updated affected code.

* RD: Minor code (mostly logging) and GUI improvements

* RD: Added 'UnknownDeviceRegistrationService' class to monitor for unknown devices (based on IP address and reference in messages received from EMS), and registering them to RD. Added NODE_DETAILS in REQUEST_TYPE enum for messages sent to/received from EMS about acquiring detailed node info (including credentials). Added 'deviceInfoRequestsTopic' and 'deviceInfoReportsTopic' settings in ResourceDiscoveryProperties.

* RD: Added prompting admin to provide device credentials when un-archiving a previously archived request or device.

* RD: Moved REQUEST_TYPE enum to 'common' package and updated code

* RD: Changed authentication to use BCrypt-encrypted passwords

* RD: Moved message broker communication code to BrokerUtil class, and updated using classes accordingly. Implemented EncryptionUtil for encrypting and decrypting broker messages [TO BE TESTED]. Few minor code improvements.

* RD: Minor code tidy up

* RD: Added support for SSL connections to ActiveMQ broker in BrokerUtil. Added the needed settings in ResourceDiscoveryProperties and application.yml

* RD: Fixed issue where UnknownDeviceRegistrationService registers a device before RegistrationRequestProcessor does

* RD: Modified pom.xml to build an image named 'eu.nebulous.resource-discovery' and tagged with current project version

* RD: Added 'DeviceLocation' class and 'location' field in both 'Device' classes. Also updated all 4 details pages to include Location (name, lat, lon). Fixed the Restore button of the modal dialog in archived.html to display 'Restore Request' or 'Restore Device' depending on the restore type.

* RD: Added StatusController to report current application status (currently returns 'OK')

* RD: Fixed a few minor issues:
* Fixed 'spring.web.resources.static-locations'
* Changed Docker image name to 'resource-discovery'
* Set BPE_LANG value to C.UTF-8 in order to render banner correctly

* RD: Changes in pom.xml and application.yml:
* Changed groupId in pom.xml to 'eu.nebulous.resource-management', and artifactId to 'resource-discovery'
* Corrected service name and description
* Set 'imageName' property to derive from artifactId
* Fixed application.yml to use '@project.version@' placeholder for app version

* RD: Renamed 'management' module to 'resource-discovery'

* RD:
* Commented out Buildpacks related settings in pom.xml
* Added Dockerfile, run.sh (entrypoint script) and .dockerignore

* RD: Modified base images in Dockerfile

* RD: Modified Dockerfile in order to both compile the app and build the Docker image

* RD: Improved Dockerfile

* RD: Improved Dockerfile

* RD: Upgraded SB version to SB 3.2.1 and JRE to version 21. Updated dependency to their latest versions. Modified model classes to avoid Lombok SuperBuilder warnings.

* RD: Fixed Dockerfile

* Initial changes to support registration and deregistration of edge devices to SAL

Introduction of Broker publisher and subscriber utilities Introduction of new device registration service

I94a6fdb4612de192c24511445f1236cdce94b000

* EMS: Added K8sNetdataCollector [WIP]

* RD: Added 'port' in forms and models

* RD: Added two TODOs

* RD: Deactivated UnknownDeviceRegistrationService

* Initial changes to support registration and deregistration of edge devices to SAL

Introduction of Broker publisher and subscriber utilities Introduction of new device registration service

I94a6fdb4612de192c24511445f1236cdce94b000

* Improvement in the initialization of SALRegistrationService I94a6fdb4612de192c24511445f1236cdce94b000

* Improvement in the initialization of SALRegistrationService I94a6fdb4612de192c24511445f1236cdce94b000

* Increased logging to debug setting of processorProperties I94a6fdb4612de192c24511445f1236cdce94b000

* Modified logging to debug the setting of processorProperties I94a6fdb4612de192c24511445f1236cdce94b000

* Correction of syntactic error I94a6fdb4612de192c24511445f1236cdce94b000

* Addition of needed configuration properties I94a6fdb4612de192c24511445f1236cdce94b000

* Testing of alternative initialization of SAL registration service I94a6fdb4612de192c24511445f1236cdce94b000

* Testing of alternative initialization of SAL registration service I94a6fdb4612de192c24511445f1236cdce94b000

* Updates on the topic and the payload format used to communicate with SAL for the registration of a device I94a6fdb4612de192c24511445f1236cdce94b000

* Allow setting and using a custom broker port I94a6fdb4612de192c24511445f1236cdce94b000

* Pass a default port to the configuration of the Resource discovery server I94a6fdb4612de192c24511445f1236cdce94b000

* Log debugging information related to the port of the NebulOuS broker I94a6fdb4612de192c24511445f1236cdce94b000

* Publishing of the appropriate message to the broker I94a6fdb4612de192c24511445f1236cdce94b000

* RD: Removed truststore settings from application.yml. Upgraded to SB 3.2.4 and fixed pom.xml

* RD: Fixed banner.txt

* RD: Modified application.yml

* RD: Added temp. debug messages

* RD: Added temp. debug messages 2

* Revert "RD: Added temp. debug messages 2"

This reverts commit 738f6048a8b88b4cfc7410db2146c7d7855c03bd.

* Revert "RD: Added temp. debug messages"

This reverts commit 31b103c207dd900689c94fe5b608a0a03db8fc80.

* RD: Modified SALRegistrationService to run SAL registration in dedicated worker thread, and interrupt registration if it takes too long. Added related settings and assigned defaults.

* RD: Added temp. log messages

* Revert "RD: Added temp. log messages"

This reverts commit 2dae6582de0359a4f33b0d8c066b1b55ecad2227.

* RD: Updated DeviceMetricsMonitorService to match metric events to device using first the IP address and the client Id (stored in Device.StatusUpdate)

* Improvements on edge device data propagation I94a6fdb4612de192c24511445f1236cdce94b000

* Integration of changes performed in commit e3bd3852 but accidentally overriden I94a6fdb4612de192c24511445f1236cdce94b000

* RD: Updated Dockerfile

* RD: Updated run.sh and added wait_for_mongodb.sh

* RD: Improved wait_for_mongodb.sh script

* Various Improvements Addition of the port attribute in the registration of an edge device Modification of the edge device registration to allow for more dynamic registration json field population I94a6fdb4612de192c24511445f1236cdce94b000

* Attempt to fix a problem when publishing to the broker to register information to SAL or notify the SLO Violation detector I94a6fdb4612de192c24511445f1236cdce94b000

* Miscellaneous improvements

Updated the registration of architecture/jar files for each edge device registered

Preliminary work to support 'Compromised state'

* RD: Added API Key authentication

* RD: Upgraded SB to 3.2.10, and Lombok, commons-lang3 dependencies to their latest versions. Improved Dockerfile.

* RD: Code improvements (esp. wrt @PreAuthorize annotations)

* RD: Made SALRegistrationService service conditionally enabled (by 'discovery.sal-registration.enabled' property). Its uses were updated accordingly.

* RD: Updated RegistrationRequestService (and its uses) to take authenticated user into consideration during checks of requests and devices sent from GUI. Also added checks for the device data provided.

* RD: Added 'Device.ref' field and added its initialization. Ref field will be populated with a unique device reference following the Nebulous naming convention (including app id).

* RD: Updated GUI pages to include the new 'ref' field. A few more improvements were introduced.

* Use device reference instead of name to register to SAL

* Improvements in device registration and component communication with the broker

* Small improvements in device registration

* Small improvement in getting device registration details

* Small improvement in getting device registration details

* RD: Fix in SALRegistrationService class

* RD: Fixed fontawesome cdn url

* Initial deregistration support

* RD: Made device on-boarding authorizatio…